### PR TITLE
refactor importing

### DIFF
--- a/exhibits/DeepMoD_PC/train_deepmod.py
+++ b/exhibits/DeepMoD_PC/train_deepmod.py
@@ -1,7 +1,8 @@
 import jax
 from jax import random, jit
 import numpy as np
-from ngclearn import Context, numpy as jnp
+from ngclearn import Context
+import jax.numpy as jnp
 # print(jax.__version__)
 from deepmod import DeepMoD
 from ngclearn.utils.feature_dictionaries.polynomialLibrary import PolynomialLibrary


### PR DESCRIPTION
normally, if we can import jax numpy directly, we should do it instead of importing the numpy module inside ngclearn